### PR TITLE
Update version of lalrpop

### DIFF
--- a/lia/Cargo.toml
+++ b/lia/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Will Crichton <wcrichto@stanford.edu>"]
 build = "build.rs"
 
 [dependencies]
-lalrpop-util = "0.11.0"
+lalrpop-util = "0.17.0"
 
 [build-dependencies]
-lalrpop = "0.11.0"
+lalrpop = "0.17.0"


### PR DESCRIPTION
Updated version of lalrpop since one of lalrpop's dependencies does not work with new versions of Rust.